### PR TITLE
feat: add totalSupply of integration shares to reward and balance

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1015,6 +1015,7 @@ type MultiPoolRewardsSnapshot @entity {
   report: Report!
   rewards: BigInt!
   commission: BigInt!
+  integrationTotalSupply: BigInt!
 
   createdAt: BigInt!
   editedAt: BigInt!
@@ -1042,6 +1043,7 @@ type ERC20BalanceSnapshot @entity {
   integration: ERC20!
   staker: Bytes!
   sharesBalance: BigInt!
+  totalSupply: BigInt!
 
   createdAt: BigInt!
   createdAtBlock: BigInt!

--- a/src/ERC20.mapping.ts
+++ b/src/ERC20.mapping.ts
@@ -65,11 +65,13 @@ function snapshotBalance(event: ethereum.Event, staker: Address): void {
   const balance = ERC20Balance.load(entityUUID(event, [staker.toHexString()]));
   const balanceSnapshotId = txUniqueUUID(event, [staker.toHexString(), blockId.toString(), ts.toString()]);
   const balanceSnapshot = new ERC20BalanceSnapshot(balanceSnapshotId);
+  const integration = ERC20.load(entityUUID(event, []));
   balanceSnapshot.integration = entityUUID(event, []);
   balanceSnapshot.staker = staker;
   balanceSnapshot.sharesBalance = balance!.sharesBalance;
   balanceSnapshot.createdAt = ts;
   balanceSnapshot.createdAtBlock = blockId;
+  balanceSnapshot.totalSupply = integration!.totalSupply;
   balanceSnapshot.save();
 }
 

--- a/src/vPool.mapping.ts
+++ b/src/vPool.mapping.ts
@@ -525,22 +525,23 @@ export function handleProcessedReport(event: ProcessedReport): void {
 
           erc20.save();
         }
+
+        const multiPoolRewardsSnapshot = new MultiPoolRewardsSnapshot(
+          eventUUID(event, [multipool!.id, report.epoch.toString()])
+        );
+        multiPoolRewardsSnapshot.multiPool = multipool!.id;
+        multiPoolRewardsSnapshot.report = reportId;
+        multiPoolRewardsSnapshot.rewards = rewards;
+        multiPoolRewardsSnapshot.commission = commission;
+        multiPoolRewardsSnapshot.integrationTotalSupply = erc20.totalSupply;
+
+        multiPoolRewardsSnapshot.createdAt = event.block.timestamp;
+        multiPoolRewardsSnapshot.editedAt = event.block.timestamp;
+        multiPoolRewardsSnapshot.createdAtBlock = event.block.number;
+        multiPoolRewardsSnapshot.editedAtBlock = event.block.number;
+        multiPoolRewardsSnapshot.save();
       }
     }
-
-    const multiPoolRewardsSnapshot = new MultiPoolRewardsSnapshot(
-      eventUUID(event, [multipool!.id, report.epoch.toString()])
-    );
-    multiPoolRewardsSnapshot.multiPool = multipool!.id;
-    multiPoolRewardsSnapshot.report = reportId;
-    multiPoolRewardsSnapshot.rewards = rewards;
-    multiPoolRewardsSnapshot.commission = commission;
-
-    multiPoolRewardsSnapshot.createdAt = event.block.timestamp;
-    multiPoolRewardsSnapshot.editedAt = event.block.timestamp;
-    multiPoolRewardsSnapshot.createdAtBlock = event.block.number;
-    multiPoolRewardsSnapshot.editedAtBlock = event.block.number;
-    multiPoolRewardsSnapshot.save();
   }
 
   const systemEvent = createReportProcessedSystemEvent(


### PR DESCRIPTION
## Adding `integrationTotalSupply` to `multiPoolRewardsSnapshots`

```graphql
{
  multiPoolRewardsSnapshots {
    rewards
    integrationTotalSupply
    multiPool {
      pool {
        address
      }
    }
  }
}
```
```json
{
  "data": {
    "multiPoolRewardsSnapshots": [
      {
        "rewards": "217260979385943",
        "integrationTotalSupply": "108315918829842271278",
        "multiPool": {
          "pool": {
            "address": "0x182e3d45efc4436edb183f4278838505a1847e21"
          }
        }
      },
      ...
    ]
  }
}
```

## Adding `totalSupply` to `erc20BalancesSnapshot`

```graphql
{
  erc20BalanceSnapshots {
    staker
    sharesBalance
    totalSupply
    integration {
      address
    }
  }
}
```
```json
{
  "data": {
    "erc20BalanceSnapshots": [
      {
        "staker": "0x260c47fc2b1ed3c65aab1f2ea597f3a9eeec5c0d",
        "sharesBalance": "1992061708063392926",
        "totalSupply": "3365977926452684870",
        "integration": {
          "address": "0x65da6aecfa84b77a25a7e83e65cd3c6bda12186c"
        }
      },
      ...
    ]
  }
}
```