### PR TITLE
fix(devnet): ignore duplicate epoch reports

### DIFF
--- a/src/vPool.mapping.ts
+++ b/src/vPool.mapping.ts
@@ -347,6 +347,10 @@ export function handleProcessedReport(event: ProcessedReport): void {
   const pool = vPool.load(event.address);
 
   const reportId = entityUUID(event, [event.params.epoch.toString()]);
+  if (Report.load(reportId) != null) {
+    // if we have the same epoch twice, it's most probably due to a manual fix
+    return;
+  }
   const report = new Report(reportId);
   const lastEpoch = pool!.lastEpoch;
 


### PR DESCRIPTION

This pull request (PR) introduces a fix for duplicate epoch reports that occur due to events being replayed on the development network (devnet). The changes ensure that if a report with the same epoch is encountered, it will not be processed again, effectively preventing redundancies.

## Summary
### Code Changes
1. **Enhanced Event Handling**: The core modification is in the event handling function `handleProcessedReport`. A conditional check has been added to ascertain if the report associated with a specific epoch already exists in the database. If it does, the function returns early, bypassing unnecessary processing of duplicate events .

2. **Report Creation Logic**: In the event that the report does not exist, a new report is created. The updated logic ensures that only unique epoch reports are considered for storage, which optimizes the handling of report data .
